### PR TITLE
chore: restore inboundBufferSize to its normal val

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -577,7 +577,6 @@ func (c *Conn) readAndBuffer(ctx context.Context) error {
 	defer poolReadBuffer.Put(bufptr)
 
 	b := *bufptr
-  b = b[128:]
 	i, err := c.nextConn.ReadContext(ctx, b)
 	if err != nil {
 		return netError(err)

--- a/conn.go
+++ b/conn.go
@@ -28,7 +28,7 @@ const (
 	cookieLength          = 20
 	sessionLength         = 32
 	defaultNamedCurve     = elliptic.X25519
-	inboundBufferSize     = 2048
+	inboundBufferSize     = 8192
 	// Default replay protection window is specified by RFC 6347 Section 4.1.2.6
 	defaultReplayProtectionWindow = 64
 )


### PR DESCRIPTION
remove optims in conn.go due to handshake problems (tentative fix)

see https://github.com/pion/dtls/blob/v2.2.6/conn.go#L31 for the default 2.2.6